### PR TITLE
accept int64 time coordinates and print time coordinate differences

### DIFF
--- a/nc_compare/.gitignore
+++ b/nc_compare/.gitignore
@@ -1,1 +1,3 @@
 /nc_compare_tests
+/nc_compare.1.html
+/docbook-xsl.css

--- a/nc_compare/NcCache.h
+++ b/nc_compare/NcCache.h
@@ -424,6 +424,9 @@ public:
   virtual void visit(nc_var<int>*)
   {};
 
+  virtual void visit(nc_var<int64_t>*)
+  {};
+
   virtual void visit(nc_var<unsigned int>*)
   {};
 
@@ -598,6 +601,7 @@ nc_datatype()
 DEFINE_TYPENAME(double,double,NC_DOUBLE)
 DEFINE_TYPENAME(float,float,NC_FLOAT)
 DEFINE_TYPENAME(int,int,NC_INT)
+DEFINE_TYPENAME(int64_t,int64_t,NC_INT64)
 DEFINE_TYPENAME(unsigned int,uint,NC_UINT)
 DEFINE_TYPENAME(short,short,NC_SHORT)
 DEFINE_TYPENAME(unsigned short,ushort,NC_USHORT)

--- a/nc_compare/NcComparison.cc
+++ b/nc_compare/NcComparison.cc
@@ -57,8 +57,8 @@ generateReport(std::ostream& out, const ReportStyle& style)
     if (leftbegin == epoch && rightbegin == epoch)
     {
       out <<
-	" *** Both base_time's are 0, files must have identical start\n"
-	"     times or else merged data will be shifted in time.\n";
+        " *** Both base_time's are 0, files must have identical start\n"
+        "     times or else merged data will be shifted in time.\n";
     }
   }
 
@@ -79,11 +79,11 @@ generateReport(std::ostream& out, const ReportStyle& style)
       if (ileft != uniqueleft.end() && 
           (iright == uniqueright.end() || *ileft < *iright))
       {
-	out << style.derive(1, " - ") << *ileft++ << "\n";
+        out << style.derive(1, " - ") << *ileft++ << "\n";
       }
       else
       {
-	out << style.derive(1, " + ") << *iright++ << "\n";
+        out << style.derive(1, " + ") << *iright++ << "\n";
       }
     }
   }
@@ -131,27 +131,27 @@ computeDifferences()
     {
       if (iright < timesright.size())
       {
-	if (timesleft[ileft] == timesright[iright])
-	{
-	  ++noverlap;
-	  ++ileft;
-	  ++iright;
-	}
-	else if (timesleft[ileft] < timesright[iright])
-	{
-	  uniqueleft.push_back(timesleft[ileft]);
-	  ++ileft;
-	}
-	else
-	{
-	  uniqueright.push_back(timesright[iright]);
-	  ++iright;
-	}
+        if (timesleft[ileft] == timesright[iright])
+        {
+          ++noverlap;
+          ++ileft;
+          ++iright;
+        }
+        else if (timesleft[ileft] < timesright[iright])
+        {
+          uniqueleft.push_back(timesleft[ileft]);
+          ++ileft;
+        }
+        else
+        {
+          uniqueright.push_back(timesright[iright]);
+          ++iright;
+        }
       }
       else
       {
-	uniqueleft.push_back(timesleft[ileft]);
-	++ileft;
+        uniqueleft.push_back(timesleft[ileft]);
+        ++ileft;
       }
     }
     else
@@ -185,7 +185,7 @@ run_comparisons(CompareNetcdf* ncf, L& left, L& right, T& comps, const F& ignore
   comps.clear();
   compare_lists(ncf, left, right, comps, ignore);
   for_each(comps.begin(), comps.end(),
-	   bind(mem_fn(&T::value_type::element_type::compare), _1));
+           bind(mem_fn(&T::value_type::element_type::compare), _1));
 }
 
 
@@ -203,7 +203,7 @@ CompareNetcdf::
 compareAttributes()
 {
   run_comparisons(this, _left->global_attributes, _right->global_attributes,
-		  atts, ignore_any_object());
+                  atts, ignore_any_object());
 }
 
 
@@ -212,13 +212,13 @@ CompareNetcdf::
 compareDimensions()
 {
   run_comparisons(this, _left->dimensions, _right->dimensions, dims,
-		  ignore_any_object());
+                  ignore_any_object());
 }
 
 
 bool
 compare_relative_error(shared_ptr<CompareVariables> x,
-		       shared_ptr<CompareVariables> y)
+                       shared_ptr<CompareVariables> y)
 {
   return x->relative_error > y->relative_error;
 }
@@ -238,7 +238,7 @@ CompareNetcdf::
 compareVariables()
 {
   run_comparisons(this, _left->variables, _right->variables, vars,
-		  ignore_variable());
+                  ignore_variable());
 }
 
 
@@ -277,8 +277,8 @@ report(std::ostream& out)
     {
       if (!header)
       {
-	cout << "global attributes:\n";
-	header = true;
+        cout << "global attributes:\n";
+        header = true;
       }
       atts[i]->generateReport(out, style.derive(1));
     }
@@ -290,8 +290,8 @@ report(std::ostream& out)
     {
       if (!header)
       {
-	cout << "variables:\n";
-	header = true;
+        cout << "variables:\n";
+        header = true;
       }
       vars[i]->generateReport(out, style.derive(1));
     }
@@ -411,11 +411,11 @@ countDifferences()
 {
   int count = 0;
   count = count_if(vars.begin(), vars.end(),
-		   bind(mem_fn(&CompareVariables::isDifferent), _1));
+                   bind(mem_fn(&CompareVariables::isDifferent), _1));
   count += count_if(dims.begin(), dims.end(),
-		    bind(mem_fn(&CompareDimensions::isDifferent), _1));
+                    bind(mem_fn(&CompareDimensions::isDifferent), _1));
   count += count_if(atts.begin(), atts.end(),
-		    bind(mem_fn(&CompareAttributes::isDifferent), _1));
+                    bind(mem_fn(&CompareAttributes::isDifferent), _1));
   count += _warnings.size();
   count += times.isDifferent();
   return count;
@@ -446,7 +446,7 @@ computeDifferences()
     if (getRight())
     {
       return (getLeft()->textSummary() == getRight()->textSummary()) ?
-	Equal : Different;
+        Equal : Different;
     }
     return Deleted;
   }
@@ -534,7 +534,7 @@ compareObjects()
 
 CompareDimensions::
 CompareDimensions(CompareNetcdf* ncf,
-		  nc_dimension* left_, nc_dimension* right_):
+                  nc_dimension* left_, nc_dimension* right_):
   CompareObjects(ncf, left_, right_)
 {
 }
@@ -729,9 +729,9 @@ computeDifferences()
 
   // Check for attribute differences.
   run_comparisons(this->_ncf, left->attributes, right->attributes,
-		  atts, ignore_any_object());
+                  atts, ignore_any_object());
   int ndiff = count_if(atts.begin(), atts.end(),
-		       bind(mem_fn(&CompareAttributes::isDifferent), _1));
+                       bind(mem_fn(&CompareAttributes::isDifferent), _1));
   equal = equal && (ndiff == 0);
   // if there are any ranges where data differs, the variables are not equal.
   if (ranges.size()) equal = false;
@@ -752,7 +752,7 @@ generateReport(std::ostream& out, const ReportStyle& style)
   }
   // Dump attribute differences next, if any.
   int ndiff = count_if(atts.begin(), atts.end(),
-		       bind(mem_fn(&CompareAttributes::isDifferent), _1));
+                       bind(mem_fn(&CompareAttributes::isDifferent), _1));
   if ((ndiff || !dimsequal ||
        (style.getShowIndex() && ranges.size()) ||
        style.getShowEqual()) && !header)
@@ -771,15 +771,15 @@ generateReport(std::ostream& out, const ReportStyle& style)
     {
       if (i < (unsigned int)style.getReportLimit())
       {
-	out << style.derive(1, " - ") << left->rangeSummary(ranges[i]) << "\n";
-	out << style.derive(1, " + ") << right->rangeSummary(ranges[i]) << "\n";
+        out << style.derive(1, " - ") << left->rangeSummary(ranges[i]) << "\n";
+        out << style.derive(1, " + ") << right->rangeSummary(ranges[i]) << "\n";
       }
     }
     // Report on the total number of different points.
     if (total_differences)
     {
       out << style.derive(1, "==>") << ranges.size() << " ranges differ, "
-	  << total_differences << " points differ out of " << left->npoints << ".\n";
+          << total_differences << " points differ out of " << left->npoints << ".\n";
     }
   }
 
@@ -804,10 +804,10 @@ namespace
    **/
   std::string
   format_stats(const ReportStyle& style,
-	       nc_variable* var,
-	       const std::string& meantitle="",
-	       const std::string& minmaxtitle="",
-	       const std::string& pointstitle="")
+               nc_variable* var,
+               const std::string& meantitle="",
+               const std::string& minmaxtitle="",
+               const std::string& pointstitle="")
   {
     std::string minmax;
     if (style.getShowMinMax())
@@ -815,7 +815,7 @@ namespace
       minmax = minmaxtitle;
       if (var)
       {
-	minmax = str(format("{%.2f, %.2f}") % var->getMin() % var->getMax());
+        minmax = str(format("{%.2f, %.2f}") % var->getMin() % var->getMax());
       }
       minmax = str(format(" %15s") % minmax);
     }
@@ -866,7 +866,7 @@ reportStatistics(std::ostream& out, const ReportStyle& style)
   out << format_stats(style, left);
   out << format_stats(style, right);
   out << (left && right ? str(format("%12.8f %12.2f %11d")
-			      % absolute_error % relative_error % total_differences) : "");
+                              % absolute_error % relative_error % total_differences) : "");
   out << "\n";
   return out;
 }
@@ -888,8 +888,8 @@ meansNearEqual()
 template <typename T>
 bool
 compare_attribute_values(CompareNetcdf* ncf,
-			 nc_attribute* attleft,
-			 nc_attribute* attright)
+                         nc_attribute* attleft,
+                         nc_attribute* attright)
 {
   nc_att<T>* left = dynamic_cast<nc_att<T>*>(attleft);
   nc_att<T>* right = dynamic_cast<nc_att<T>*>(attright);

--- a/nc_compare/NcComparison.cc
+++ b/nc_compare/NcComparison.cc
@@ -68,22 +68,24 @@ generateReport(std::ostream& out, const ReportStyle& style)
       << "Right file time period: " << rightbegin << " - " << rightend << "\n";
   out << style
       << "Number of times in common: " << noverlap << "\n";
-  if (style.getShowIndex())
+  if (style.getShowTimes())
   {
+    auto rleft = style.derive(1, " - ");
+    auto rright = style.derive(1, " + " + std::string(40, ' '));
     auto ileft = uniqueleft.begin();
     auto iright = uniqueright.begin();
     int n = 0;
-    while (ileft != uniqueleft.end() && iright != uniqueright.end() &&
+    while ((ileft != uniqueleft.end() || iright != uniqueright.end()) &&
            ++n <= style.getReportLimit())
     {
       if (ileft != uniqueleft.end() && 
           (iright == uniqueright.end() || *ileft < *iright))
       {
-        out << style.derive(1, " - ") << *ileft++ << "\n";
+        out << rleft << *ileft++ << "\n";
       }
       else
       {
-        out << style.derive(1, " + ") << *iright++ << "\n";
+        out << rright << *iright++ << "\n";
       }
     }
   }
@@ -123,41 +125,37 @@ computeDifferences()
   uniqueleft.clear();
   uniqueright.clear();
 
-  unsigned int ileft = 0;
-  unsigned int iright = 0;
-  while (ileft < timesleft.size() || iright < timesright.size())
+  auto ileft = timesleft.begin();
+  auto iright = timesright.begin();
+  while (ileft != timesleft.end() || iright != timesright.end())
   {
-    if (ileft < timesleft.size())
+    if (ileft != timesleft.end())
     {
-      if (iright < timesright.size())
+      if (iright != timesright.end())
       {
-        if (timesleft[ileft] == timesright[iright])
+        if (*ileft == *iright)
         {
           ++noverlap;
           ++ileft;
           ++iright;
         }
-        else if (timesleft[ileft] < timesright[iright])
+        else if (*ileft < *iright)
         {
-          uniqueleft.push_back(timesleft[ileft]);
-          ++ileft;
+          uniqueleft.push_back(*ileft++);
         }
         else
         {
-          uniqueright.push_back(timesright[iright]);
-          ++iright;
+          uniqueright.push_back(*iright++);
         }
       }
       else
       {
-        uniqueleft.push_back(timesleft[ileft]);
-        ++ileft;
+        uniqueleft.push_back(*ileft++);
       }
     }
     else
     {
-      uniqueright.push_back(timesright[iright]);
-      ++iright;
+      uniqueright.push_back(*iright++);
     }
   }
   unsigned int ntotal = noverlap + uniqueleft.size() + uniqueright.size();

--- a/nc_compare/NcComparison.h
+++ b/nc_compare/NcComparison.h
@@ -156,7 +156,7 @@ public:
   generateReport(std::ostream& out, const ReportStyle& style)
   {
     throw CompareNetcdfException("FileComparison does not implement "
-				 "generateReport()");
+                                 "generateReport()");
   }
 
 protected:
@@ -238,7 +238,7 @@ class CompareDimensions : public CompareObjects<nc_dimension>
 {
 public:
   CompareDimensions(CompareNetcdf* ncf,
-		    nc_dimension* left, nc_dimension* right);
+                    nc_dimension* left, nc_dimension* right);
 
   virtual Result
   computeDifferences();

--- a/nc_compare/NcComparison.h
+++ b/nc_compare/NcComparison.h
@@ -191,16 +191,16 @@ protected:
   nc_time rightend;
 
   /// Number of times which are in common between the two files.
-  int noverlap;
+  unsigned int noverlap;
 
   /// Percentage of times in common out of union of all times.
   float percent_overlap;
 
-  /// Number of times on left side which are unique.
-  int nuniqueleft;
+  /// Times on left side which are unique.
+  std::vector<nc_time> uniqueleft;
 
-  /// Number of times on right side which are unique.
-  int nuniqueright;
+  /// Times on right side which are unique.
+  std::vector<nc_time> uniqueright;
 
 };
 

--- a/nc_compare/ReportStyle.cc
+++ b/nc_compare/ReportStyle.cc
@@ -12,7 +12,8 @@ ReportStyle(int indent):
   _show_equal(false),
   _show_index(false),
   _report_limit(DEFAULT_REPORT_LIMIT),
-  _minmax(false)
+  _minmax(false),
+  _show_times(false)
 {}
 
 

--- a/nc_compare/ReportStyle.h
+++ b/nc_compare/ReportStyle.h
@@ -41,6 +41,18 @@ public:
   }
 
   void
+  showTimes(bool flag)
+  {
+    _show_times = flag;
+  }
+
+  bool
+  getShowTimes() const
+  {
+    return _show_times;
+  }
+
+  void
   useRightBlanks(bool flag)
   {
     _use_right_blanks = flag;
@@ -136,6 +148,7 @@ private:
   bool _use_right_blanks;
   int _report_limit;
   bool _minmax;
+  bool _show_times;
 };
 
 

--- a/nc_compare/gsl.hh
+++ b/nc_compare/gsl.hh
@@ -40,6 +40,7 @@ gsl_stats_minmax(T* min, T* max, \
   GSL_STATS(double,)
   GSL_STATS(float,float_)
   GSL_STATS(int,int_)
+  GSL_STATS(int64_t,long_)
   GSL_STATS(unsigned int,uint_)
   GSL_STATS(short,short_)
   GSL_STATS(unsigned short,ushort_)

--- a/nc_compare/nc_compare.cc
+++ b/nc_compare/nc_compare.cc
@@ -30,6 +30,7 @@ nc_compare(int argc, char *argv[])
     ("showequal", "Show equal objects as well as different.")
     ("showindex",
      "For vector values, report the indexes of the differences.")
+    ("showtimes", "Report different time coordinates.")
     ("ignore", po::value<std::vector<std::string> >()->composing(),
      "Ignore attributes and variables with the given name.  "
      "Add * as suffix or prefix to match a substring.  "
@@ -123,6 +124,7 @@ nc_compare(int argc, char *argv[])
   ReportStyle& style = ncdiff.style();
   style.showEqual(vm.count("showequal") > 0);
   style.showIndex(vm.count("showindex") > 0);
+  style.showTimes(vm.count("showtimes") > 0);
   style.useRightBlanks(vm.count("use-right-blanks") > 0);
   style.showMinMax(vm.count("minmax") > 0);
 


### PR DESCRIPTION
These changes allow comparing hotfilm netcdf files with an int64 time coordinate and units "microseconds since ...".  Since the units have always been assumed to be "seconds", this code now enforces that the units must start with either "seconds" or "microseconds", and then it sets the time step accordingly.  I don't think this should break other uses of `nc_compare`, but it's the most likely potential impact.

Time coordinate differences can be printed with the new `--showtimes` option, where before there was only a summary of the number of unique times in each file.

`basetime_from_units()` could still be more robust about checking that the units string was correctly parsed, such as by checking the `sscanf()` and `strptime()` return values, but I'll leave it for someone else to decide if that should be a separate issue.  I guess it hasn't been a problem so far...
