### PR TITLE
handle variables of different types w/out crashing

### DIFF
--- a/nc_compare/NcCache.h
+++ b/nc_compare/NcCache.h
@@ -295,6 +295,9 @@ struct nc_variable : public nc_object
   virtual void
   loadValues() = 0;
 
+  virtual double
+  getDouble(const coordinates& where) = 0;
+
   virtual void
   computeStatistics(nc_variable* blanks = 0) = 0;
 
@@ -393,6 +396,12 @@ public:
   get(const coordinates& where)
   {
     return data[where.index];
+  }
+
+  virtual double
+  getDouble(const coordinates& where) override
+  {
+    return static_cast<double>(get(where));
   }
 
   virtual bool

--- a/nc_compare/NcComparison.cc
+++ b/nc_compare/NcComparison.cc
@@ -586,9 +586,17 @@ compare_variables(CompareNetcdf* ncf, nc_var<T>* left, nc_variable* _right)
   }
   do
   {
-    // If not blanked on the right and not near equal, add to a range.
-    if ((!blanks || !blanks->isMissing(coords.index)) &&
-        !ncf->near_equal(left->get(coords), right->get(coords)))
+    // If blanked on the right or near equal, then consider that a match.  Add
+    // to a range whatever coordinates do not match.  If the types are
+    // different, then compare the values cast to double.
+    bool matched = (blanks && blanks->isMissing(coords.index));
+    if (!matched && right)
+      matched = ncf->near_equal(left->get(coords), right->get(coords));
+    else if (!matched)
+      matched = ncf->near_equal(left->getDouble(coords), 
+                                _right->getDouble(coords));
+
+    if (!matched)
     {
       if (!inrange)
       {

--- a/nc_compare/nc_compare.cc
+++ b/nc_compare/nc_compare.cc
@@ -24,7 +24,17 @@ nc_compare(int argc, char *argv[])
 {
   // Declare the supported options.
   po::options_description
-    desc("nc_compare [options] primary_file secondary_file");
+    desc(
+R"(Usage: nc_compare [options] left_file right_file
+
+Compare two netCDF files and report the differences.  Differences can be
+reported between global attributes, dimensions, variables, variable
+attributes, and time coordinates, as well as statistical or per-element
+comparisons of variable data.  Variables with different types between the left
+and right file report the different types in the variable headings, and the
+variable values themselves are compared as doubles.
+
+Options)");
   desc.add_options()
     ("help", "Show this help message.")
     ("showequal", "Show equal objects as well as different.")


### PR DESCRIPTION
Try this out on the latest crash, and merge it if it doesn't seem to break anything.

If the right variable cannot be cast to the same nc_var<T> as the left, then use the new virtual getDouble() method to compare the values as doubles. Perhaps not the most efficient way to compare different types, but effective, and it provides more information than just skipping the variable.
